### PR TITLE
Fix MUI Tabs component value type mismatch error

### DIFF
--- a/src/api/desktopApi.ts
+++ b/src/api/desktopApi.ts
@@ -24,7 +24,7 @@ export const desktopApi = {
   // Get pending file paths from Rust backend
   async getPendingFilePaths(): Promise<string[]> {
     try {
-      const paths = await invoke<string[]>('get_pending_file_paths');
+      const paths = await invoke<string[]>('get_pending_file_paths_command');
       return paths;
     } catch (error: unknown) {
       console.error('Error getting pending file paths:', error);
@@ -44,7 +44,7 @@ export const desktopApi = {
   // Notify Rust that frontend is ready
   async setFrontendReady(): Promise<void> {
     try {
-      await invoke('set_frontend_ready');
+      await invoke('set_frontend_ready_command');
     } catch (error: unknown) {
       console.error('Error setting frontend ready:', error);
     }

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -254,8 +254,11 @@ const TabBar: React.FC<TabBarProps> = ({
     })
   );
 
-  const handleTabClick = (_event: React.SyntheticEvent, tabId: string) => {
-    onTabChange(tabId);
+  const handleTabClick = (_event: React.SyntheticEvent, tabIndex: number) => {
+    const tab = tabs[tabIndex];
+    if (tab) {
+      onTabChange(tab.id);
+    }
   };
 
   const handleTabClose = (event: React.MouseEvent, tabId: string) => {
@@ -344,7 +347,15 @@ const TabBar: React.FC<TabBarProps> = ({
             strategy={horizontalListSortingStrategy}
           >
             <Tabs
-              value={activeTabId && tabs.find(t => t.id === activeTabId) ? activeTabId : false}
+              value={(() => {
+                if (!activeTabId) return false;
+                const tabIndex = tabs.findIndex(t => t.id === activeTabId);
+                if (tabIndex === -1) {
+                  console.warn('Invalid activeTabId:', activeTabId, 'Available tabs:', tabs.map(t => t.id));
+                  return false;
+                }
+                return tabIndex;
+              })()}
               onChange={handleTabClick}
               variant="scrollable"
               scrollButtons="auto"

--- a/src/hooks/useTabsDesktop.ts
+++ b/src/hooks/useTabsDesktop.ts
@@ -74,7 +74,12 @@ export const useTabsDesktop = () => {
   const setActiveTab = useCallback(async (id: string) => {
     const tab = state.tabs.find(t => t.id === id);
     if (!tab) {
-      dispatch({ type: 'SET_ACTIVE_TAB', payload: { id } });
+      // 存在しないタブIDの場合は、最初のタブをアクティブにするか、nullにする
+      if (state.tabs.length > 0) {
+        dispatch({ type: 'SET_ACTIVE_TAB', payload: { id: state.tabs[0].id } });
+      } else {
+        dispatch({ type: 'SET_ACTIVE_TAB', payload: { id: null } });
+      }
       return;
     }
 

--- a/src/reducers/tabReducer.ts
+++ b/src/reducers/tabReducer.ts
@@ -36,11 +36,14 @@ export const tabReducer = (state: TabState, action: TabAction): TabState => {
       };
     }
 
-    case 'SET_ACTIVE_TAB':
+    case 'SET_ACTIVE_TAB': {
+      // 存在するタブIDのみを許可
+      const tabExists = state.tabs.some(tab => tab.id === action.payload.id);
       return {
         ...state,
-        activeTabId: action.payload.id,
+        activeTabId: tabExists ? action.payload.id : null,
       };
+    }
 
     case 'UPDATE_TAB_CONTENT':
       return {
@@ -102,18 +105,33 @@ export const tabReducer = (state: TabState, action: TabAction): TabState => {
         ),
       };
 
-    case 'REORDER_TABS':
-      return {
-        ...state,
-        tabs: action.payload.tabs,
-      };
+    case 'REORDER_TABS': {
+      // アクティブタブIDが存在するかチェック
+      const validActiveTabId = state.activeTabId &&
+        action.payload.tabs.some(tab => tab.id === state.activeTabId)
+        ? state.activeTabId
+        : (action.payload.tabs.length > 0 ? action.payload.tabs[0].id : null);
 
-    case 'LOAD_STATE':
       return {
         ...state,
         tabs: action.payload.tabs,
-        activeTabId: action.payload.activeTabId,
+        activeTabId: validActiveTabId,
       };
+    }
+
+    case 'LOAD_STATE': {
+      // アクティブタブIDが存在するかチェック
+      const validActiveTabId = action.payload.activeTabId &&
+        action.payload.tabs.some(tab => tab.id === action.payload.activeTabId)
+        ? action.payload.activeTabId
+        : (action.payload.tabs.length > 0 ? action.payload.tabs[0].id : null);
+
+      return {
+        ...state,
+        tabs: action.payload.tabs,
+        activeTabId: validActiveTabId,
+      };
+    }
 
     default:
       return state;

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -26,7 +26,7 @@ export interface AppState {
 export type TabAction =
   | { type: 'ADD_TAB'; payload: Tab }
   | { type: 'REMOVE_TAB'; payload: { id: string } }
-  | { type: 'SET_ACTIVE_TAB'; payload: { id: string } }
+  | { type: 'SET_ACTIVE_TAB'; payload: { id: string | null } }
   | { type: 'UPDATE_TAB_CONTENT'; payload: { id: string; content: string } }
   | { type: 'UPDATE_TAB_TITLE'; payload: { id: string; title: string } }
   | { type: 'SET_TAB_MODIFIED'; payload: { id: string; isModified: boolean } }


### PR DESCRIPTION
## Problem
The application was throwing the following MUI Tabs error on startup:

## Root Cause
MUI's Tabs component expects a numeric index for the `value` prop, but we were passing string IDs (e.g., `"tab-1757757847474-xoby3exhv"`).

## Testing
- [x] Startup error resolved
- [x] Tab switching works correctly
- [x] No TypeScript or ESLint errors